### PR TITLE
Really fix link to Uses page history on GitHub

### DIFF
--- a/src/pages/uses/index.mdx
+++ b/src/pages/uses/index.mdx
@@ -274,4 +274,4 @@ https://www.youtube.com/watch?v=N3wY9kNnmQA
 ## Old setup
 
 To learn what this page looked like in the past, checkout
-[the file history on GitHub](https://github.com/kentcdodds/kentcdodds.com/commits/master/src/pages/uses.mdx)
+[the file history on GitHub](https://github.com/kentcdodds/kentcdodds.com/commits/main/src/pages/uses.mdx)


### PR DESCRIPTION
unfortunately, master is not redirected to main for `/commits...` links ¯\\\_(ツ)_/¯